### PR TITLE
Migrate TabExpansion to Register-ArgumentCompleter

### DIFF
--- a/CondaTabExpansion.psd1
+++ b/CondaTabExpansion.psd1
@@ -19,10 +19,10 @@
     FileList = @('CondaTabExpansion.ps1', 'CondaTabExpansion.psm1')
     
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion = '3.0'
+    PowerShellVersion = '5.0'
     
     # Functions to export from this module
-    FunctionsToExport = '*'
+    FunctionsToExport = @()
     
     # Cmdlets to export from this module
     CmdletsToExport = @()
@@ -31,7 +31,7 @@
     VariablesToExport = @()
     
     # Aliases to export from this module
-    AliasesToExport = '*'
+    AliasesToExport = @()
     
     # Private data to pass to the module specified in RootModule/ModuleToProcess.
     # This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/CondaTabExpansion.psm1
+++ b/CondaTabExpansion.psm1
@@ -1,5 +1,3 @@
 if (Get-Module CondaTabExpansion) { return }
 
 . "$PSScriptRoot\CondaTabExpansion.ps1"
-
-Export-ModuleMember -Alias refreshenv -Function 'TabExpansion'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > *You can now download `CondaTabExpansion` from PowerShell Gallery!* [(here)](https://www.powershellgallery.com/packages/CondaTabExpansion/0.1.1)
 
-This module provides **full support** of `conda` command completion in PowerShell (for version 3 and up supposedly). You can tab and fill commands as if you were running in `bash` or other shells.
+This module provides **full support** of `conda` command completion in PowerShell (for version 5 and up supposedly). You can tab and fill commands as if you were running in `bash` or other shells.
 
 This project is inspired by the `ChocolateyTabExpansion` script in `Chocolatey` [(here)](https://github.com/chocolatey/choco).
 


### PR DESCRIPTION
After PowerShell 5.0, there's a new function [`Register-ArgumentCompleter`](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/register-argumentcompleter?view=powershell-5.1&WT.mc_id=ps-gethelp) to register completers for commands. `TabExpansion` works before, in PowerShell 7.4.0, it doesn't work any more. That seems is the time to migrate to `Register-ArgumentCompleter`.